### PR TITLE
suggested edit

### DIFF
--- a/src/app/infra/utils.go
+++ b/src/app/infra/utils.go
@@ -5,15 +5,13 @@ import (
 	"time"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
+var r = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 func RandString(n int) string {
 	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+		b[i] = letterRunes[r.Intn(len(letterRunes))]
 	}
 	return string(b)
 }


### PR DESCRIPTION
This will prevent this package from stomping on the global rand seed. You could also move the `r` declaration into `RandString`, but this way allows you to override `r` easily in unit tests so you can have deterministic results from `RandString`.